### PR TITLE
bump submodule to `main`, not `master`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "src/paas-sqs-broker"]
 	path = src/paas-sqs-broker
 	url = https://github.com/alphagov/paas-sqs-broker
+	branch = main


### PR DESCRIPTION
I updated the submodule by running

    git submodule update --remote

thinking that it would update to latest.  Unfortunately due to the
weird way submodules work, the branch to pull wasn't specified
anywhere, so it defaulted to `master`, which we don't use any more.

This changes the .gitmodules configuration so that this command will
pull `main` now, and bumps the submodule to the correct commit.